### PR TITLE
fix: 保留仅含金额的导入持仓

### DIFF
--- a/backend/api/migrations/0015_position_source_market_value_and_more.py
+++ b/backend/api/migrations/0015_position_source_market_value_and_more.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0014_widen_report_frequency"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="position",
+            name="source_market_value",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                help_text="数据源仅提供金额时的持仓市值快照",
+                max_digits=20,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="positionoperation",
+            name="source_market_value",
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=2,
+                help_text="数据源仅提供金额时的当前市值快照",
+                max_digits=20,
+                null=True,
+            ),
+        ),
+    ]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -142,12 +142,7 @@ class Account(models.Model):
         else:
             # 子账户：汇总所有持仓
             return sum(
-                (
-                    pos.fund.latest_nav * pos.holding_share
-                    for pos in self.positions.all()
-                    if pos.fund.latest_nav
-                ),
-                Decimal("0"),
+                (pos.holding_value for pos in self.positions.all()), Decimal("0")
             )
 
     @property
@@ -184,6 +179,9 @@ class Account(models.Model):
             has_any = False
             for pos in self.positions.all():
                 if pos.fund.estimate_nav is None:
+                    if pos.source_market_value is not None:
+                        total += pos.source_market_value
+                        has_any = True
                     continue
                 total += pos.fund.estimate_nav * pos.holding_share
                 has_any = True
@@ -263,6 +261,13 @@ class Position(models.Model):
     holding_share = models.DecimalField(max_digits=20, decimal_places=4, default=0)
     holding_cost = models.DecimalField(max_digits=20, decimal_places=2, default=0)
     holding_nav = models.DecimalField(max_digits=10, decimal_places=4, default=0)
+    source_market_value = models.DecimalField(
+        max_digits=20,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="数据源仅提供金额时的持仓市值快照",
+    )
 
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -289,11 +294,20 @@ class Position(models.Model):
         super().save(*args, **kwargs)
 
     @property
+    def holding_value(self):
+        """持仓市值"""
+        from decimal import Decimal
+
+        if self.source_market_value is not None:
+            return self.source_market_value
+        if not self.fund.latest_nav or self.holding_share == 0:
+            return Decimal("0")
+        return self.fund.latest_nav * self.holding_share
+
+    @property
     def pnl(self):
         """盈亏（实时计算）"""
-        if not self.fund.latest_nav or self.holding_share == 0:
-            return 0
-        return (self.fund.latest_nav - self.holding_nav) * self.holding_share
+        return self.holding_value - self.holding_cost
 
 
 class PositionOperation(models.Model):
@@ -317,6 +331,13 @@ class PositionOperation(models.Model):
     amount = models.DecimalField(max_digits=20, decimal_places=2)
     share = models.DecimalField(max_digits=20, decimal_places=4)
     nav = models.DecimalField(max_digits=10, decimal_places=4, help_text="操作时的净值")
+    source_market_value = models.DecimalField(
+        max_digits=20,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        help_text="数据源仅提供金额时的当前市值快照",
+    )
 
     created_at = models.DateTimeField(auto_now_add=True)
 

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -150,6 +150,9 @@ class PositionSerializer(serializers.ModelSerializer):
     fund_name = serializers.CharField(source="fund.fund_name", read_only=True)
     fund_type = serializers.CharField(source="fund.fund_type", read_only=True)
     account_name = serializers.CharField(source="account.name", read_only=True)
+    holding_value = serializers.DecimalField(
+        max_digits=20, decimal_places=2, read_only=True
+    )
     pnl = serializers.DecimalField(max_digits=20, decimal_places=2, read_only=True)
 
     # 添加基金的估值和净值信息
@@ -191,6 +194,7 @@ class PositionSerializer(serializers.ModelSerializer):
             "holding_share",
             "holding_cost",
             "holding_nav",
+            "holding_value",
             "pnl",
             "updated_at",
         ]

--- a/backend/api/services/__init__.py
+++ b/backend/api/services/__init__.py
@@ -38,12 +38,17 @@ def recalculate_position(account_id, fund_id) -> Optional[Position]:
 
     total_share = Decimal("0")
     total_cost = Decimal("0")
+    source_market_value = None
 
     for op in operations:
         if op.operation_type == "BUY":
             # 买入：增加份额和成本
             total_share += op.share
             total_cost += op.amount
+            if op.source_market_value is not None:
+                source_market_value = op.source_market_value
+            elif op.share > 0:
+                source_market_value = None
         elif op.operation_type == "SELL":
             # 卖出：按比例减少成本
             if total_share > 0:
@@ -77,7 +82,7 @@ def recalculate_position(account_id, fund_id) -> Optional[Position]:
 
     # 更新或创建 Position（使用对象而不是 ID）
     with transaction.atomic():
-        if total_share > 0:
+        if total_share > 0 or source_market_value is not None:
             # 有持仓：更新或创建
             position, created = Position.objects.update_or_create(
                 account=account,
@@ -86,6 +91,7 @@ def recalculate_position(account_id, fund_id) -> Optional[Position]:
                     "holding_share": total_share,
                     "holding_cost": total_cost,
                     "holding_nav": holding_nav,
+                    "source_market_value": source_market_value,
                 },
             )
             return position

--- a/backend/api/services/import_xiaobeiyangji.py
+++ b/backend/api/services/import_xiaobeiyangji.py
@@ -110,8 +110,23 @@ def import_from_xiaobeiyangji(user, source, overwrite: bool = False) -> dict:
                 share = Decimal(str(holding["share"])).quantize(
                     Decimal("0.0001"), rounding=ROUND_DOWN
                 )
-                # amount = 买入总成本 = share × nav，不用外部 market value
-                amount = (share * nav).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+                source_market_value = None
+                if share > 0 and nav > 0:
+                    amount = (share * nav).quantize(
+                        Decimal("0.01"), rounding=ROUND_DOWN
+                    )
+                else:
+                    imported_market_value = Decimal(str(holding["amount"])).quantize(
+                        Decimal("0.01"), rounding=ROUND_DOWN
+                    )
+                    if imported_market_value > 0:
+                        source_market_value = imported_market_value
+                        earnings = Decimal(str(holding.get("earnings", 0)))
+                        amount = max(
+                            source_market_value - earnings, Decimal("0")
+                        ).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+                    else:
+                        amount = Decimal("0")
 
                 PositionOperation.objects.create(
                     account=sub_account,
@@ -122,6 +137,7 @@ def import_from_xiaobeiyangji(user, source, overwrite: bool = False) -> dict:
                     share=share,
                     nav=nav,
                     amount=amount,
+                    source_market_value=source_market_value,
                 )
                 result["holdings_created"] += 1
 

--- a/backend/api/services/import_yjb.py
+++ b/backend/api/services/import_yjb.py
@@ -108,8 +108,23 @@ def import_from_yangjibao(user, source, overwrite: bool = False) -> dict:
                 share = Decimal(str(holding["share"])).quantize(
                     Decimal("0.0001"), rounding=ROUND_DOWN
                 )
-                # amount = 买入总成本 = share × nav，不用外部 market value
-                amount = (share * nav).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+                source_market_value = None
+                if share > 0 and nav > 0:
+                    amount = (share * nav).quantize(
+                        Decimal("0.01"), rounding=ROUND_DOWN
+                    )
+                else:
+                    imported_market_value = Decimal(str(holding["amount"])).quantize(
+                        Decimal("0.01"), rounding=ROUND_DOWN
+                    )
+                    if imported_market_value > 0:
+                        source_market_value = imported_market_value
+                        earnings = Decimal(str(holding.get("earnings", 0)))
+                        amount = max(
+                            source_market_value - earnings, Decimal("0")
+                        ).quantize(Decimal("0.01"), rounding=ROUND_DOWN)
+                    else:
+                        amount = Decimal("0")
 
                 PositionOperation.objects.create(
                     account=sub_account,
@@ -120,6 +135,7 @@ def import_from_yangjibao(user, source, overwrite: bool = False) -> dict:
                     share=share,
                     nav=nav,
                     amount=amount,
+                    source_market_value=source_market_value,
                 )
                 result["holdings_created"] += 1
 

--- a/backend/api/sources/yangjibao.py
+++ b/backend/api/sources/yangjibao.py
@@ -454,6 +454,7 @@ class YangJiBaoSource(BaseEstimateSource):
             hold_share = h.get("hold_share")
             hold_cost = h.get("hold_cost")
             money = h.get("money")
+            hold_earn = h.get("hold_earn")
             hold_day = h.get("hold_day")
 
             if not fund_code or hold_share is None or hold_cost is None:
@@ -476,6 +477,7 @@ class YangJiBaoSource(BaseEstimateSource):
                             if money
                             else Decimal(str(hold_share)) * Decimal(str(hold_cost))
                         ),
+                        "earnings": Decimal(str(hold_earn or 0)),
                         "operation_date": operation_date,
                     }
                 )

--- a/backend/tests/test_account_serializer.py
+++ b/backend/tests/test_account_serializer.py
@@ -105,6 +105,28 @@ class TestAccountSerializerWithSummary:
         assert data["children"][0]["id"] == str(child_account.id)
         assert data["children"][0]["name"] == "子账户"
 
+    def test_amount_only_position_is_included_in_account_summary(
+        self, child_account, fund
+    ):
+        """测试金额型持仓参与账户市值和盈亏汇总"""
+        from api.models import Position
+        from api.serializers import AccountSerializer
+
+        Position.objects.create(
+            account=child_account,
+            fund=fund,
+            holding_share=Decimal("0"),
+            holding_cost=Decimal("1000.00"),
+            holding_nav=Decimal("0"),
+            source_market_value=Decimal("1200.00"),
+        )
+
+        data = AccountSerializer(child_account).data
+
+        assert Decimal(data["holding_cost"]) == Decimal("1000.00")
+        assert Decimal(data["holding_value"]) == Decimal("1200.00")
+        assert Decimal(data["pnl"]) == Decimal("200.00")
+
     def test_parent_account_serializer_includes_summary_fields(
         self, client, user, parent_account, child_account, fund
     ):

--- a/backend/tests/test_models_position.py
+++ b/backend/tests/test_models_position.py
@@ -226,6 +226,31 @@ class TestPositionCalculation:
         assert position.holding_cost == Decimal("1000")
         assert position.holding_nav == Decimal("10")
 
+    def test_amount_only_buy_calculation(self, account, fund):
+        """测试缺少份额和净值时使用来源市值快照"""
+        from api.models import PositionOperation
+        from api.services import recalculate_position
+
+        PositionOperation.objects.create(
+            account=account,
+            fund=fund,
+            operation_type="BUY",
+            operation_date=date(2024, 3, 1),
+            amount=Decimal("1000.00"),
+            share=Decimal("0"),
+            nav=Decimal("0"),
+            source_market_value=Decimal("1200.00"),
+        )
+
+        position = recalculate_position(account.id, fund.id)
+
+        assert position is not None
+        assert position.holding_share == Decimal("0")
+        assert position.holding_cost == Decimal("1000.00")
+        assert position.source_market_value == Decimal("1200.00")
+        assert position.holding_value == Decimal("1200.00")
+        assert position.pnl == Decimal("200.00")
+
     def test_multiple_buy_calculation(self, account, fund):
         """测试多次加仓计算"""
         from api.models import PositionOperation

--- a/backend/tests/test_yjb_import.py
+++ b/backend/tests/test_yjb_import.py
@@ -187,6 +187,40 @@ class TestYangJiBaoFetchHoldings:
 
         assert result == []
 
+    @patch("api.sources.yangjibao.requests.request")
+    def test_fetch_holdings_preserves_amount_only_holding(self, mock_request):
+        """测试保留仅提供市值和收益的持仓"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "code": 200,
+            "data": [
+                {
+                    "code": "009999",
+                    "short_name": "示例金额型基金",
+                    "hold_share": 0,
+                    "hold_cost": 0,
+                    "money": "1200.00",
+                    "hold_earn": "200.00",
+                    "hold_day": "2024-03-01",
+                }
+            ],
+        }
+        mock_request.return_value = mock_response
+
+        from api.sources.yangjibao import YangJiBaoSource
+
+        source = YangJiBaoSource()
+        source._token = "test-token"
+
+        result = source.fetch_holdings("acc-001")
+
+        assert len(result) == 1
+        assert result[0]["share"] == Decimal("0")
+        assert result[0]["nav"] == Decimal("0")
+        assert result[0]["amount"] == Decimal("1200.00")
+        assert result[0]["earnings"] == Decimal("200.00")
+
     def test_fetch_holdings_no_token(self):
         """测试未登录时抛出异常"""
         from api.sources.yangjibao import YangJiBaoSource
@@ -293,6 +327,42 @@ class TestImportFromYangJiBao:
         assert "holdings_skipped" in result
         assert result["accounts_created"] == 1
         assert result["holdings_created"] == 1
+
+    def test_import_creates_amount_only_position(self, user):
+        """测试金额型持仓保留来源市值和真实成本"""
+        from api.models import Account, Position, PositionOperation
+        from api.services.import_yjb import import_from_yangjibao
+
+        source = Mock()
+        source.fetch_accounts.return_value = [
+            {"account_id": "acc-amount", "name": "示例账户"},
+        ]
+        source.fetch_holdings.return_value = [
+            {
+                "fund_code": "009999",
+                "fund_name": "示例金额型基金",
+                "share": Decimal("0"),
+                "nav": Decimal("0"),
+                "amount": Decimal("1200.00"),
+                "earnings": Decimal("200.00"),
+                "operation_date": date(2024, 3, 1),
+            }
+        ]
+
+        result = import_from_yangjibao(user, source)
+
+        account = Account.objects.get(user=user, name="示例账户")
+        operation = PositionOperation.objects.get(account=account)
+        position = Position.objects.get(account=account)
+
+        assert result["holdings_created"] == 1
+        assert operation.amount == Decimal("1000.00")
+        assert operation.source_market_value == Decimal("1200.00")
+        assert position.holding_share == Decimal("0")
+        assert position.holding_cost == Decimal("1000.00")
+        assert position.holding_value == Decimal("1200.00")
+        assert position.pnl == Decimal("200.00")
+        assert account.holding_value == Decimal("1200.00")
 
     def test_import_idempotent_accounts(self, user, mock_source):
         """测试重复导入账户不重复创建"""

--- a/frontend/src/components/PositionCharts.jsx
+++ b/frontend/src/components/PositionCharts.jsx
@@ -28,11 +28,9 @@ const PositionCharts = ({ positions, accountId }) => {
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState(null);
 
-  // 计算市值：holding_share * latest_nav
+  // 使用后端统一计算的持仓市值，兼容仅提供金额的持仓
   const calculateMarketValue = (position) => {
-    const share = parseFloat(position.holding_share || 0);
-    const nav = parseFloat(position.fund?.latest_nav || 0);
-    return share * nav;
+    return parseFloat(position.holding_value || 0);
   };
 
   // 计算账户总市值和总成本

--- a/frontend/src/pages/PositionsPage.jsx
+++ b/frontend/src/pages/PositionsPage.jsx
@@ -862,15 +862,11 @@ const PositionsPage = () => {
       key: 'holding_value',
       width: 120,
       sorter: (a, b) => {
-        const va = parseFloat(a.holding_share || 0) * parseFloat(a.fund?.latest_nav || 0);
-        const vb = parseFloat(b.holding_share || 0) * parseFloat(b.fund?.latest_nav || 0);
+        const va = parseFloat(a.holding_value || 0);
+        const vb = parseFloat(b.holding_value || 0);
         return va - vb;
       },
-      render: (_, record) => {
-        const value =
-          parseFloat(record.holding_share || 0) * parseFloat(record.fund?.latest_nav || 0);
-        return formatMoney(value);
-      },
+      render: (_, record) => formatMoney(record.holding_value),
     },
     {
       title: '盈亏金额',


### PR DESCRIPTION
## 问题

部分数据源在隐私展示模式下会将持仓份额和成本净值返回为 `0`，但仍提供当前市值和累计收益。原导入逻辑使用“份额 × 净值”重算金额，随后又删除零份额持仓，导致这类基金未出现在账户汇总和持仓页面中。

## 修复

- 为持仓流水和持仓汇总增加可选的来源市值快照。
- 对仅含金额的持仓，使用“当前市值 - 累计收益”还原持仓成本。
- 重算时保留具有来源市值的零份额持仓。
- 后端统一输出 `holding_value`，账户汇总、持仓列表和图表使用该字段。
- 同时兼容养基宝和小倍养基导入，并补充通用测试数据。

## 验证

- `black --check`：通过。
- `python manage.py makemigrations api --check --dry-run`：通过。
- 后端定向测试：`20 passed`。
- 前端 `npm run build`：通过。
